### PR TITLE
HTML-384: Added support for ajax autocomplete provider to EncounterPr…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 .DS_Store
 *.iml
+*.ipr
+*.iws

--- a/api/src/main/java/org/openmrs/module/htmlformentry19ext/ProviderAjaxAutoCompleteWidget.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry19ext/ProviderAjaxAutoCompleteWidget.java
@@ -1,0 +1,141 @@
+package org.openmrs.module.htmlformentry19ext;
+
+import org.openmrs.Provider;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.htmlformentry.FormEntryContext;
+import org.openmrs.module.htmlformentry19ext.element.ProviderStub;
+import org.openmrs.module.htmlformentry.widget.Widget;
+import org.openmrs.module.htmlformentry.widget.WidgetFactory;
+import org.openmrs.module.htmlformentry19ext.util.MatchMode;
+import org.springframework.util.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class ProviderAjaxAutoCompleteWidget implements Widget {
+
+    private MatchMode matchMode = MatchMode.START;
+
+    private Provider initialValue;
+    private final String SRC = "providers";
+
+    public MatchMode getMatchMode() {
+        return matchMode;
+    }
+
+    public void setMatchMode(MatchMode matchMode) {
+        if(matchMode == null) this.matchMode = MatchMode.ANYWHERE;
+        else this.matchMode = matchMode;
+    }
+
+    @Override
+    public void setInitialValue(Object initialValue) {
+         this.initialValue = (Provider)initialValue;
+    }
+
+    @Override
+    public String generateHtml(FormEntryContext context) {
+
+        StringBuilder sb = new StringBuilder();
+        if (context.getMode().equals(FormEntryContext.Mode.VIEW)) {
+            String toPrint = "";
+            if (initialValue != null) {
+                toPrint = initialValue.getName();
+                return WidgetFactory.displayValue(toPrint);
+            } else {
+                return WidgetFactory.displayEmptyValue("___________");
+            }
+        } else {
+            String placeholder = Context.getMessageSourceService().getMessage("htmlformentry19ext.providerPlaceHolder");
+            sb.append("<input type=\"text\"  id=\""
+                    + context.getFieldName(this) + "\"" + " name=\""
+                    + context.getFieldName(this) + "\" "
+                    + " onfocus=\"setupProviderAutocomplete(this, '" + this.SRC + "');\""
+                    + " class=\"autoCompleteText\""
+                    + " onchange=\"setValWhenAutocompleteFieldBlanked(this)\""
+                    + " onblur=\"onBlurAutocomplete(this)\""
+                    + " placeholder = \"" + placeholder + "\"");
+
+            if (initialValue != null)
+                sb.append(" value=\"" + (new ProviderStub(initialValue).getDisplayValue()) + "\"");
+            sb.append("/>\n");
+
+            //Add hidden field for provider match mode
+            sb.append("<input type='hidden' id='").append(context.getFieldName(this)+"_matchMode_hid'").
+                    append(" value='").append(matchMode).append("' />\n");
+
+            sb.append("<input name=\"" + context.getFieldName(this) + "_hid"
+                    + "\" id=\"" + context.getFieldName(this) + "_hid" + "\""
+                    + " type=\"hidden\" class=\"autoCompleteHidden\" ");
+            if (initialValue != null) {
+                sb.append(" value=\"" + initialValue.getProviderId() + "\"");
+            }
+            sb.append("/> \n");
+        }
+        sb.append(createJsAutoCompleteFunction());
+
+        return sb.toString();
+    }
+
+    @Override
+    public Object getValue(FormEntryContext context, HttpServletRequest request) {
+        String value = request.getParameter(context.getFieldName(this)+"_hid");
+        Provider provider = null;
+        if(StringUtils.hasText(value)) {
+            provider = Context.getProviderService().getProvider(Integer.valueOf(value));
+        }
+        return provider;
+    }
+
+    private String createJsAutoCompleteFunction() {
+        StringBuilder sb = new StringBuilder("<script type=\"text/javascript\">\n");
+        sb.append("function setupProviderAutocomplete(element,src) {");
+        sb.append("    var hiddenField = jQuery(\"#\"+element.id+\"_hid\");\n");
+        sb.append("    var textField = jQuery(element); \n");
+        sb.append("    var providerMatchMode = jQuery(\"#\"+element.id+\"_matchMode_hid\"); \n");
+        sb.append("    var select = false;");
+
+        sb.append("    var req = { 'searchParam': textField.val()};\n");
+
+        sb.append("    if (hiddenField.length > 0 && textField.length > 0) { \n");
+        sb.append("        textField.autocomplete( { \n");
+        sb.append("          source: function(req, add){ \n");
+        sb.append("            //pass request to server  \n");
+
+        sb.append("            jQuery.getJSON(location.protocol + '//' + location.host + getContextPath() + " +
+                "'/ws/module/htmlformentry19ext/' + src ," +
+                "{\"searchParam\":textField.val(), 'matchMode':providerMatchMode.val()}, function(data) { \n");
+
+        sb.append("                //create array for response objects \n");
+        sb.append("                var suggestions = [];");
+        sb.append("                jQuery.each(data,function(i,val){ \n");
+        sb.append("                    var item = {}; ");
+        sb.append("                    item.label = val.displayValue; \n");
+        sb.append("                   item.value = val.providerId; \n");
+        sb.append("                    suggestions.push(item);  \n");
+        sb.append("                }); \n");
+
+        sb.append("\n");
+        sb.append("                if (suggestions.length==0) { \n");
+        sb.append("                     hiddenField.val(''); \n");
+        sb.append("                     textField.css('color','red'); \n");
+        sb.append("                } \n");
+        sb.append("                add(suggestions);  \n");
+        sb.append("            }); \n");
+        sb.append("        }, \n");
+
+        sb.append("        minLength: 2, \n");
+        sb.append("        select: function(event, ui) {\n");
+        sb.append("            hiddenField.val(ui.item.value); \n");
+        sb.append("            textField.val(ui.item.label); \n");
+        sb.append("            textField.css('color','black') \n");
+        sb.append("            select = true; \n");
+        sb.append("            return false; \n");
+        sb.append("        }  \n");
+        sb.append("      });  \n");
+        sb.append("    }   \n");
+        sb.append("} \n");
+        sb.append("</script>\n");
+
+        return sb.toString();
+    }
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry19ext/ProviderAndRoleElement.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry19ext/ProviderAndRoleElement.java
@@ -26,7 +26,9 @@ import org.openmrs.module.htmlformentry.FormSubmissionError;
 import org.openmrs.module.htmlformentry.action.FormSubmissionControllerAction;
 import org.openmrs.module.htmlformentry.element.HtmlGeneratorElement;
 import org.openmrs.module.htmlformentry.widget.ErrorWidget;
+import org.openmrs.module.htmlformentry.widget.Widget;
 import org.openmrs.module.htmlformentry19ext.util.HtmlFormEntryExtensions19Utils;
+import org.openmrs.module.htmlformentry19ext.util.MatchMode;
 import org.springframework.util.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
@@ -49,11 +51,15 @@ public class ProviderAndRoleElement implements HtmlGeneratorElement, FormSubmiss
 
 	EncounterRoleWidget roleWidget;
 	ErrorWidget roleErrorWidget;
-	List<ProviderWidget> providerWidgets = new ArrayList<ProviderWidget>();
+	List<Widget> providerWidgets = new ArrayList<Widget>();
 	List<ErrorWidget> providerErrorWidgets = new ArrayList<ErrorWidget>();
 	
 	// in case EncounterRole is specified as a parameter to the tag
 	EncounterRole encounterRole;
+
+    // Whether autocomplete or dropdown (default is dropdown)
+    private boolean autocompleteProvider = false;
+    private MatchMode providerMatchMode = null;
 
     public ProviderAndRoleElement() {
         // just used for testing, you should always initialize with the constructor below
@@ -64,6 +70,20 @@ public class ProviderAndRoleElement implements HtmlGeneratorElement, FormSubmiss
 	 * @throws BadFormDesignException 
      */
     public ProviderAndRoleElement(FormEntryContext context, Map<String, String> parameters) throws BadFormDesignException {
+
+        if(parameters.containsKey("autocompleteProvider")) {
+            autocompleteProvider = Boolean.valueOf(parameters.get("autocompleteProvider"));
+            if(parameters.containsKey("providerMatchMode")) {
+                try {
+                    String value = parameters.get("providerMatchMode");
+                    if(value != null) {
+                        providerMatchMode = MatchMode.valueOf(value);
+                    }
+                }catch (IllegalArgumentException ie) {
+                    providerMatchMode = MatchMode.ANYWHERE;
+                }
+            }
+        }
 
         if (parameters.containsKey("required")) {
     		required = Boolean.valueOf(parameters.get("required"));
@@ -91,40 +111,55 @@ public class ProviderAndRoleElement implements HtmlGeneratorElement, FormSubmiss
     		context.registerErrorWidget(roleWidget, roleErrorWidget);
     	}
 
-        // get the list of providers we want to use
-        List<Provider> providerList = getProviderList(parameters);
-
         boolean initialProviderSet = false;
 
-        // handle the case where no encounterRole attribute is specified
         if (encounterRole == null) {
             if (count > 1) {
-                throw new BadFormDesignException("HTML Form Entry does not (yet) support multiple providers per encounter without specifying encounter roles");
+                throw new BadFormDesignException("HTML Form Entry does not (yet) support multiple providers per " +
+                        "encounter without specifying encounter roles");
             }
 
-            ProviderWidget providerWidget = new ProviderWidget();
-            providerWidget.setProviders(providerList);
-            ErrorWidget providerErrorWidget = new ErrorWidget();
+            Widget providerWidget;
+            ErrorWidget providerErrorWidget;
+            if(!autocompleteProvider) {
+                // get the list of providers we want to use
+                List<Provider> providerList = getProviderList(parameters);
+
+                // handle the case where no encounterRole attribute is specified
+
+                providerWidget = new ProviderWidget();
+                ((ProviderWidget)providerWidget).setProviders(providerList);
+                providerErrorWidget = new ErrorWidget();
+
+
+            } else { //autocomplete provider
+                providerWidget = new ProviderAjaxAutoCompleteWidget();
+                if(providerMatchMode != null) {
+                    ((ProviderAjaxAutoCompleteWidget) providerWidget).setMatchMode(providerMatchMode);
+                }
+            }
+            providerErrorWidget = new ErrorWidget();
             context.registerWidget(providerWidget);
             context.registerErrorWidget(providerWidget, providerErrorWidget);
             providerWidgets.add(providerWidget);
             providerErrorWidgets.add(providerErrorWidget);
 
-            if (context.getExistingEncounter() != null) {
-                Map<EncounterRole, Set<Provider>> byRoles = context.getExistingEncounter().getProvidersByRoles();
-                if (byRoles.size() > 0) {
-                    // currently we only support a single provider in this mode
-                    if (byRoles.size() > 1 || byRoles.values().iterator().next().size() > 1) {
-                        throw new BadFormDesignException("HTML Form Entry does not (yet) support multiple providers per encounter without specifying encounter roles");
-                    }
+                if (context.getExistingEncounter() != null) {
+                    Map<EncounterRole, Set<Provider>> byRoles = context.getExistingEncounter().getProvidersByRoles();
+                    if (byRoles.size() > 0) {
+                        // currently we only support a single provider in this mode
+                        if (byRoles.size() > 1 || byRoles.values().iterator().next().size() > 1) {
+                            throw new BadFormDesignException("HTML Form Entry does not (yet) support multiple " +
+                                    "providers per encounter without specifying encounter roles");
+                        }
 
-                    Entry<EncounterRole, Set<Provider>> roleAndProvider = byRoles.entrySet().iterator().next();
-                    Provider p = roleAndProvider.getValue().iterator().next();
-                    providerWidget.setInitialValue(p);
-                    initialProviderSet = true;
-                    roleWidget.setInitialValue(roleAndProvider.getKey());
+                        Entry<EncounterRole, Set<Provider>> roleAndProvider = byRoles.entrySet().iterator().next();
+                        Provider p = roleAndProvider.getValue().iterator().next();
+                        providerWidget.setInitialValue(p);
+                        initialProviderSet = true;
+                        roleWidget.setInitialValue(roleAndProvider.getKey());
+                    }
                 }
-            }
         }
         // handle the case where an encounter role is specified
         else {
@@ -136,20 +171,42 @@ public class ProviderAndRoleElement implements HtmlGeneratorElement, FormSubmiss
             }
 
             // register the provider widgets, setting any existing provider values
-    	    for (int currentIteration = 0; currentIteration < count; currentIteration++) {
+            if(!autocompleteProvider) {
+                List<Provider> providerList = getProviderList(parameters);
+                for (int currentIteration = 0; currentIteration < count; currentIteration++) {
 
-                ProviderWidget providerWidget = new ProviderWidget();
-                providerWidget.setProviders(providerList);
-                ErrorWidget providerErrorWidget = new ErrorWidget();
-                context.registerWidget(providerWidget);
-                context.registerErrorWidget(providerWidget, providerErrorWidget);
-                providerWidgets.add(providerWidget);
-                providerErrorWidgets.add(providerErrorWidget);
+                    ProviderWidget providerWidget = new ProviderWidget();
+                    providerWidget.setProviders(providerList);
+                    ErrorWidget providerErrorWidget = new ErrorWidget();
+                    context.registerWidget(providerWidget);
+                    context.registerErrorWidget(providerWidget, providerErrorWidget);
+                    providerWidgets.add(providerWidget);
+                    providerErrorWidgets.add(providerErrorWidget);
 
-                if (byRole != null && byRole.size() > currentIteration) {
-    				providerWidget.setInitialValue(byRole.get(currentIteration));
-    				initialProviderSet = true;
-    			}
+                    if (byRole != null && byRole.size() > currentIteration) {
+                        providerWidget.setInitialValue(byRole.get(currentIteration));
+                        initialProviderSet = true;
+                    }
+                }
+            }  else { //Handle autocomplete
+                for(int currentIteration = 0; currentIteration < count; currentIteration++) {
+                    Widget providerWidget = new ProviderAjaxAutoCompleteWidget();
+                    if(providerMatchMode != null) {
+                        ((ProviderAjaxAutoCompleteWidget) providerWidget).setMatchMode(providerMatchMode);
+                    }
+
+                    ErrorWidget providerErrorWidget = new ErrorWidget();
+                    context.registerWidget(providerWidget);
+                    context.registerErrorWidget(providerWidget,providerErrorWidget);
+
+                    providerWidgets.add(providerWidget);
+                    providerErrorWidgets.add(providerErrorWidget);
+
+                    if (byRole != null && byRole.size() > currentIteration) {
+                        providerWidget.setInitialValue(byRole.get(currentIteration));
+                        initialProviderSet = true;
+                    }
+                }
             }
         }
 
@@ -189,7 +246,7 @@ public class ProviderAndRoleElement implements HtmlGeneratorElement, FormSubmiss
     	}
 
         Iterator<ErrorWidget> errorWidgetIterator = providerErrorWidgets.iterator();
-        for (ProviderWidget providerWidget : providerWidgets) {
+        for (Widget providerWidget : providerWidgets) {
 			ret.append(providerWidget.generateHtml(context));
 			if (context.getMode() != Mode.VIEW) {
 				ret.append(errorWidgetIterator.next().generateHtml(context));
@@ -220,7 +277,7 @@ public class ProviderAndRoleElement implements HtmlGeneratorElement, FormSubmiss
 
         boolean atLeastOneProviderSpecified = false;
 
-        for (ProviderWidget providerWidget : providerWidgets) {
+        for (Widget providerWidget : providerWidgets) {
             if (providerWidget != null) {
                 provider = (Provider) providerWidget.getValue(context, submission);
                 if (provider != null) {
@@ -250,7 +307,7 @@ public class ProviderAndRoleElement implements HtmlGeneratorElement, FormSubmiss
 
         Set<Provider> currentProvidersForRole = session.getSubmissionActions().getCurrentEncounter().getProvidersByRole(role);
 
-        for (ProviderWidget providerWidget : providerWidgets) {
+        for (Widget providerWidget : providerWidgets) {
     		provider = (Provider) providerWidget.getValue(session.getContext(), submission);
 
             if (provider != null) {

--- a/api/src/main/java/org/openmrs/module/htmlformentry19ext/element/ProviderStub.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry19ext/element/ProviderStub.java
@@ -1,0 +1,77 @@
+package org.openmrs.module.htmlformentry19ext.element;
+
+import org.openmrs.Person;
+import org.openmrs.Provider;
+import org.openmrs.module.htmlformentry.element.ValueStub;
+import org.springframework.util.StringUtils;
+
+public class ProviderStub extends ValueStub {
+    private Integer providerId;
+    private String identifier;
+    private String name;
+    private String uuid;
+
+    public ProviderStub(Provider provider) {
+        if(provider != null) {
+            setId(provider.getProviderId());
+            this.providerId = provider.getProviderId();
+            this.identifier = provider.getIdentifier();
+            if (StringUtils.hasLength(provider.getName())) {
+                this.name = provider.getName();
+            } else {
+                //Use person names if they exist.
+                Person p = provider.getPerson();
+                if (p != null) {
+                    this.name = p.getGivenName() + " " + p.getFamilyName() + ", " + p.getMiddleName();
+                }
+            }
+            this.uuid = provider.getUuid();
+        }
+    }
+
+    public Integer getProviderId() {
+        return providerId;
+    }
+
+    public void setProviderId(Integer providerId) {
+        this.providerId = providerId;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    @Override
+    public String getDisplayValue() {
+        return name + (StringUtils.hasLength(identifier)? " ("+identifier+")" : "");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if(o != null && o instanceof ProviderStub){
+            ProviderStub other = (ProviderStub)o;
+            return this.getProviderId().intValue() == other.getProviderId().intValue();
+        }
+        return false;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry19ext/util/MatchMode.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry19ext/util/MatchMode.java
@@ -1,0 +1,5 @@
+package org.openmrs.module.htmlformentry19ext.util;
+
+public enum MatchMode {
+    START, ANYWHERE, END;
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry19ext/util/Predicate.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry19ext/util/Predicate.java
@@ -1,0 +1,5 @@
+package org.openmrs.module.htmlformentry19ext.util;
+
+public interface Predicate<T> {
+    boolean test(T t);
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry19ext/util/ProviderTransformer.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry19ext/util/ProviderTransformer.java
@@ -1,0 +1,19 @@
+package org.openmrs.module.htmlformentry19ext.util;
+
+import org.openmrs.Provider;
+import org.openmrs.module.htmlformentry19ext.element.ProviderStub;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class ProviderTransformer implements Transformer<Provider,ProviderStub> {
+    @Override
+    public Collection<ProviderStub> transform(Collection<Provider> collection, Predicate<Provider> predicate) {
+        List<ProviderStub> providerStubs = new ArrayList<ProviderStub>();
+        for(Provider p:collection) {
+            if(predicate.test(p)) providerStubs.add(new ProviderStub(p));
+        }
+        return providerStubs;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/htmlformentry19ext/util/Transformer.java
+++ b/api/src/main/java/org/openmrs/module/htmlformentry19ext/util/Transformer.java
@@ -1,0 +1,7 @@
+package org.openmrs.module.htmlformentry19ext.util;
+
+import java.util.Collection;
+
+public interface Transformer<T,V> {
+    Collection<V>  transform(Collection<T> collection,Predicate<T> predicate);
+}

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -2,3 +2,4 @@ ${project.parent.artifactId}.title=HTML Form Entry Extensions for OpenMRS 1.9 Mo
 ${project.parent.artifactId}.chooseAnEncounterRole=Choose an Encounter Role
 ${project.parent.artifactId}.chooseAProvider=Choose a provider
 ${project.parent.artifactId}.unknownProviderName=Unknown
+${project.parent.artifactId}.providerPlaceHolder=Type identifier or name

--- a/api/src/test/java/org/openmrs/module/htmlformentry19ext/util/HtmlFormEntry19ExtUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/htmlformentry19ext/util/HtmlFormEntry19ExtUtilsTest.java
@@ -1,14 +1,26 @@
 package org.openmrs.module.htmlformentry19ext.util;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.PersonName;
+import org.openmrs.Provider;
+import org.openmrs.api.ProviderService;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.htmlformentry19ext.element.ProviderStub;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
+
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class HtmlFormEntry19ExtUtilsTest extends BaseModuleContextSensitiveTest {
+
+    @Before
+    public void setup() throws Exception{
+       executeDataSet("org/openmrs/module/htmlformentry19ext/include/provider-dataset.xml");
+    }
 
     @Test
     public void getFullNameWithFamilyNameFirst_shouldReturnProperSimpleName() {
@@ -50,5 +62,93 @@ public class HtmlFormEntry19ExtUtilsTest extends BaseModuleContextSensitiveTest 
 		assertThat(HtmlFormEntryExtensions19Utils.getFullNameWithFamilyNameFirst(null), is("["
 		        + Context.getMessageSourceService().getMessage("htmlformentry19ext.unknownProviderName") + "]"));
 	}
+
+    /**
+     * Tests for person names associated with a person object attached to the provider object.
+     */
+    @Test
+    public  void getProviders_shouldReturnProviderStubsWhosePersonNamesStartWithAGivenString() {
+        ProviderService providerService = Context.getProviderService();
+
+        String search = "sura";
+        List<Provider> providers = providerService.getProviders(search, null, null, null);
+        List<ProviderStub> providerStubs =
+                HtmlFormEntryExtensions19Utils.getProviderStubs(providers,search,MatchMode.START);
+        Provider provider = providerService.getProvider(13002);    //From provider-dataset.xml
+
+        assertTrue(providerStubs.contains(new ProviderStub(provider)));
+    }
+
+    /**
+     * This tests for names stored directly in provider object as name field.
+     */
+    @Test
+    public void getProviders_shouldReturnProvidersStubsWhoseProviderNameStartWithAGivenString() {
+        ProviderService providerService = Context.getProviderService();
+        String search = "kisa";
+        List<Provider> providers = providerService.getProviders(search,null,null,null);
+        List<ProviderStub> providerStubs = HtmlFormEntryExtensions19Utils.getProviderStubs(providers,search,MatchMode.START);
+        Provider provider = providerService.getProvider(13010);          //From provider-datasets.xml
+
+        assertTrue(providerStubs.contains(new ProviderStub(provider)));
+    }
+
+    /**
+     * Tests for provider identifier stored in provider object
+     */
+    @Test
+    public void getProviders_shouldReturnProviderStubsWhoseIdentifiersStartWithAGivenString() {
+        ProviderService providerService = Context.getProviderService();
+        String search = "5566-1";
+        List<Provider> providers = providerService.getProviders(search,null,null,null);
+        List<ProviderStub> providerStubs = HtmlFormEntryExtensions19Utils.getProviderStubs(providers,search,MatchMode.START);
+        Provider provider = providerService.getProvider(13002);
+
+        assertTrue(providerStubs.contains(new ProviderStub(provider)));
+    }
+
+    /**
+     * This tests for names stores as person names stored as names of associated person object.
+     */
+    @Test
+    public void getProviders_shouldReturnProviderStubsWhosePersonNamesEndsWithAString() {
+        ProviderService providerService = Context.getProviderService();
+        String search = "rathne";
+        List<Provider> providers = providerService.getProviders(search, null, null, null);
+        List<ProviderStub> providerStubs =
+                HtmlFormEntryExtensions19Utils.getProviderStubs(providers,search,MatchMode.END);
+        Provider provider = providerService.getProvider(13002);    //From provider-dataset.xml
+
+        assertTrue(providerStubs.contains(new ProviderStub(provider)));
+    }
+
+
+    /**
+     * Tests for names stored directly in provider object as a name field
+     */
+    @Test
+    public void getProviders_shouldReturnProviderStubsWhoseProviderNamesEndWithAGivenString() {
+        ProviderService providerService = Context.getProviderService();
+        String search = "Sanga";
+        List<Provider> providers = providerService.getProviders(search,null,null,null);
+        List<ProviderStub> providerStubs = HtmlFormEntryExtensions19Utils.getProviderStubs(providers,search,MatchMode.END);
+        Provider provider = providerService.getProvider(13010);          //From provider-datasets.xml
+
+        assertTrue(providerStubs.contains(new ProviderStub(provider)));
+    }
+
+    /**
+     * Tests for provider identifier stored in provider table
+     */
+    @Test
+    public void getProviders_shouldReturnProviderStubsWhoseIdentifierEndsWithAGivenString() {
+        ProviderService providerService = Context.getProviderService();
+        String search = "05-999";
+        List<Provider> providers = providerService.getProviders(search,null,null,null);
+        List<ProviderStub> providerStubs = HtmlFormEntryExtensions19Utils.getProviderStubs(providers,search,MatchMode.END);
+        Provider provider = providerService.getProvider(13010);
+
+        assertTrue(providerStubs.contains(new ProviderStub(provider)));
+    }
 
 }

--- a/api/src/test/resources/org/openmrs/module/htmlformentry19ext/include/provider-dataset.xml
+++ b/api/src/test/resources/org/openmrs/module/htmlformentry19ext/include/provider-dataset.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+    <person person_id="13000" gender="M" voided="0" creator="1" date_created="2015-06-07" dead="false"
+            uuid="de8140e0-1691-11df-97a5-7038c432aabf" />
+    <person_name person_name_id="13001" person_id="13000" given_name="suranga" family_name="kasthurirathne" voided="false"
+            preferred="true" creator="1" date_created="2015-06-07" uuid="de814b7c-1691-11df-97a5-7038c432aabf"/>
+
+    <provider provider_id="13002" person_id="13000" identifier="5566-111" retired="false" creator="1"
+              date_created="2015-06-07"/>
+    <provider provider_id="13010" name="Thomas Kisanga Kilemule" identifier="34005-999" retired="false"  creator="1"
+              date_created="2015-06-07"/>
+</dataset>

--- a/omod/src/main/java/org/openmrs/module/htmlformentry19ext/web/controller/HtmlFormEntry19ExController.java
+++ b/omod/src/main/java/org/openmrs/module/htmlformentry19ext/web/controller/HtmlFormEntry19ExController.java
@@ -1,0 +1,42 @@
+package org.openmrs.module.htmlformentry19ext.web.controller;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.Provider;
+import org.openmrs.api.ProviderService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.htmlformentry19ext.element.ProviderStub;
+import org.openmrs.module.htmlformentry19ext.util.HtmlFormEntryExtensions19Utils;
+import org.openmrs.module.htmlformentry19ext.util.MatchMode;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.List;
+
+@Controller
+public class HtmlFormEntry19ExController {
+    private Log log = LogFactory.getLog(HtmlFormEntry19ExController.class);
+
+    @RequestMapping("/module/htmlformentry19ext/providers")
+    @ResponseBody
+    public Object getProviders(@RequestParam(value="searchParam",required = false) String searchParam,
+                               @RequestParam(value="matchMode",required=false)MatchMode matchMode)
+            throws Exception {
+        ProviderService ps = Context.getProviderService();
+
+        List<Provider> providerList = null;
+        List<ProviderStub> ret = null;
+        if(searchParam == null) {
+            providerList = ps.getAllProviders();
+            ret = HtmlFormEntryExtensions19Utils.getProviderStubs(providerList);
+        }
+        else {
+            providerList = ps.getProviders(searchParam, null, null, null);
+            ret = HtmlFormEntryExtensions19Utils.getProviderStubs(providerList,searchParam,matchMode);
+        }
+
+        return ret;
+    }
+}


### PR DESCRIPTION
…oviderAndRole tag. To accomplish this I have added support for two attributes.

1. autocompleteProvider which can take values true/false (Dafault is false)
2. providerMatchMode which is used to specifiy how matching is done when the text to be searched is submitted via ajax. This takes one of the three
   values namely "START", "END", "ANYWHERE" with "START" as default.

Matching is done per standard OpenMRS API (i.e. via ProviderService).